### PR TITLE
Making the scroll proxy a public getter.

### DIFF
--- a/NoChat/Source/ChatViewController.swift
+++ b/NoChat/Source/ChatViewController.swift
@@ -92,7 +92,7 @@ public class ChatViewController: UIViewController {
     
     // Detect touches in status bar
     // http://stackoverflow.com/questions/3753097/how-to-detect-touches-in-status-bar
-    private var scrollProxy: UIScrollView!
+    public private(set) var scrollProxy: UIScrollView!
     private func addScrollProxyView() {
         scrollProxy = UIScrollView()
         scrollProxy.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
I'm trying to add a view behind `ChatViewController` to occasionally add user interactions hide the but the `scrollViewProxy`keeps swallowing my gestures.

I want to be able to turn these views on and off.

So, like the other views, I made them a public getter and a private setter
