### PR TITLE
Fix reference to match file name.

### DIFF
--- a/NoChat/NoChat/NoChat.h
+++ b/NoChat/NoChat/NoChat.h
@@ -35,4 +35,4 @@ FOUNDATION_EXPORT const unsigned char NoChatVersionString[];
 #import <NoChat/NOCChatItemCell.h>
 #import <NoChat/NOCChatItemCellLayout.h>
 #import <NoChat/NOCChatInputPanel.h>
-#import <NoChat/NoCChatViewController.h>
+#import <NoChat/NOCChatViewController.h>


### PR DESCRIPTION
Enables building on case-sensitive file systems. Either way doesn't seem to be a good reason not to have this consistent in the main header.